### PR TITLE
Add Supabase example pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # Learning
+
+This repository contains simple HTML pages that demonstrate using [Supabase](https://supabase.com) for authentication and storing data.
+
+## Setup
+
+1. Create a Supabase project and copy your **Project URL** and **Anon API Key**.
+2. In `public/supabase.js`, replace `YOUR_SUPABASE_URL` and `YOUR_SUPABASE_ANON_KEY` with your credentials.
+3. In Supabase, create three tables:
+   - **vocabulary**: columns `id` (bigint, auto increment, primary key), `word` (text), `definition` (text).
+   - **symbols**: columns `id` (bigint, auto increment, primary key), `symbol` (text), `value` (text).
+   - **formulas**: columns `id` (bigint, auto increment, primary key), `formula` (text), `description` (text).
+
+## Running locally
+
+1. Open this folder in Visual Studio Code.
+2. Install the **Live Server** extension if you do not already have it.
+3. Right click an HTML file (for example `public/login.html`) and choose **Open with Live Server**. Your default browser will open with the page running on a local server.
+4. Use the signup page to create an account, then log in and try adding vocabulary words, symbols, and formulas.
+5. After submitting a form, refresh the page to verify that the stored data loads from Supabase.
+

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Dashboard</title>
+</head>
+<body>
+<h1>Dashboard</h1>
+<nav>
+  <ul>
+    <li><a href="vocabulary.html">Vocabulary</a></li>
+    <li><a href="symbols.html">Symbols</a></li>
+    <li><a href="formulas.html">Formulas</a></li>
+  </ul>
+</nav>
+</body>
+</html>
+

--- a/public/forgot-password.html
+++ b/public/forgot-password.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Forgot Password</title>
+</head>
+<body>
+<h1>Forgot Password</h1>
+<form id="forgot-form">
+  <input type="email" name="email" placeholder="Email" required />
+  <button type="submit">Send Reset Email</button>
+</form>
+<p><a href="login.html">Back to login</a></p>
+<div id="message"></div>
+
+<script type="module">
+import { requestPasswordReset } from './supabase.js'
+
+const form = document.getElementById('forgot-form')
+const message = document.getElementById('message')
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault()
+  const email = form.email.value.trim()
+  const { error } = await requestPasswordReset(email)
+  if (error) {
+    message.textContent = error.message
+  } else {
+    message.textContent = 'Check your email for the reset link.'
+  }
+})
+</script>
+</body>
+</html>
+

--- a/public/formulas.html
+++ b/public/formulas.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Formulas</title>
+</head>
+<body>
+<h1>Formulas</h1>
+<form id="formula-form">
+  <input name="formula" placeholder="Formula" required />
+  <input name="description" placeholder="Description" required />
+  <button type="submit">Add</button>
+</form>
+<ul id="formula-list"></ul>
+
+<script type="module">
+import { insertFormula, fetchFormulas } from './supabase.js'
+
+const form = document.getElementById('formula-form')
+const list = document.getElementById('formula-list')
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault()
+  const formula = form.formula.value.trim()
+  const description = form.description.value.trim()
+  if (!formula || !description) return
+  const { error } = await insertFormula(formula, description)
+  if (error) {
+    alert(error.message)
+  } else {
+    form.reset()
+    load()
+  }
+})
+
+async function load() {
+  const { data, error } = await fetchFormulas()
+  if (error) {
+    list.innerHTML = '<li>Failed to load formulas</li>'
+    return
+  }
+  list.innerHTML = ''
+  data.forEach(item => {
+    const li = document.createElement('li')
+    li.textContent = `${item.formula}: ${item.description}`
+    list.appendChild(li)
+  })
+}
+
+load()
+</script>
+</body>
+</html>
+

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Login</title>
+</head>
+<body>
+<h1>Login</h1>
+<form id="login-form">
+  <input type="email" name="email" placeholder="Email" required />
+  <input type="password" name="password" placeholder="Password" required />
+  <button type="submit">Login</button>
+</form>
+<p>Don't have an account? <a href="signup.html">Sign up</a></p>
+
+<script type="module">
+import { signIn } from './supabase.js'
+
+const form = document.getElementById('login-form')
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault()
+  const email = form.email.value.trim()
+  const password = form.password.value.trim()
+  if (!email || !password) return
+  const { error } = await signIn(email, password)
+  if (error) {
+    alert(error.message)
+  } else {
+    window.location.href = 'dashboard.html'
+  }
+})
+</script>
+</body>
+</html>
+

--- a/public/reset-password.html
+++ b/public/reset-password.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Reset Password</title>
+</head>
+<body>
+<h1>Reset Password</h1>
+<form id="reset-form">
+  <input type="password" name="password" placeholder="New password" required />
+  <input type="password" name="confirm" placeholder="Confirm password" required />
+  <button type="submit">Reset Password</button>
+</form>
+<div id="message"></div>
+
+<script type="module">
+import { updatePassword } from './supabase.js'
+
+const form = document.getElementById('reset-form')
+const message = document.getElementById('message')
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault()
+  const password = form.password.value.trim()
+  const confirm = form.confirm.value.trim()
+  if (password !== confirm) {
+    message.textContent = 'Passwords do not match.'
+    return
+  }
+  const { error } = await updatePassword(password)
+  if (error) {
+    message.textContent = error.message
+  } else {
+    message.textContent = 'Password updated. Please log in.'
+    setTimeout(() => {
+      window.location.href = 'login.html'
+    }, 1000)
+  }
+})
+</script>
+</body>
+</html>
+

--- a/public/signup.html
+++ b/public/signup.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Sign Up</title>
+</head>
+<body>
+<h1>Sign Up</h1>
+<form id="signup-form">
+  <input type="email" name="email" placeholder="Email" required />
+  <input type="password" name="password" placeholder="Password" required />
+  <button type="submit">Sign Up</button>
+</form>
+<p>Already have an account? <a href="login.html">Login</a></p>
+
+<script type="module">
+import { signUp } from './supabase.js'
+
+const form = document.getElementById('signup-form')
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault()
+  const email = form.email.value.trim()
+  const password = form.password.value.trim()
+  if (!email || !password) return
+  const { error } = await signUp(email, password)
+  if (error) {
+    alert(error.message)
+  } else {
+    alert('Signup successful. Please login.')
+    window.location.href = 'login.html'
+  }
+})
+</script>
+</body>
+</html>
+

--- a/public/supabase.js
+++ b/public/supabase.js
@@ -1,0 +1,58 @@
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm'
+
+// TODO: Replace with your Supabase project credentials
+const SUPABASE_URL = 'YOUR_SUPABASE_URL'
+const SUPABASE_KEY = 'YOUR_SUPABASE_ANON_KEY'
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_KEY)
+
+export async function signUp(email, password) {
+  const { error } = await supabase.auth.signUp({ email, password })
+  return { error }
+}
+
+export async function signIn(email, password) {
+  const { error } = await supabase.auth.signInWithPassword({ email, password })
+  return { error }
+}
+
+export async function requestPasswordReset(email) {
+  const { error } = await supabase.auth.resetPasswordForEmail(email)
+  return { error }
+}
+
+export async function updatePassword(newPassword) {
+  const { error } = await supabase.auth.updateUser({ password: newPassword })
+  return { error }
+}
+
+export async function insertVocabulary(word, definition) {
+  const { error } = await supabase.from('vocabulary').insert([{ word, definition }])
+  return { error }
+}
+
+export async function fetchVocabulary() {
+  const { data, error } = await supabase.from('vocabulary').select('*').order('id', { ascending: true })
+  return { data, error }
+}
+
+export async function insertSymbol(symbol, value) {
+  const { error } = await supabase.from('symbols').insert([{ symbol, value }])
+  return { error }
+}
+
+export async function fetchSymbols() {
+  const { data, error } = await supabase.from('symbols').select('*').order('id', { ascending: true })
+  return { data, error }
+}
+
+export async function insertFormula(formula, description) {
+  const { error } = await supabase.from('formulas').insert([{ formula, description }])
+  return { error }
+}
+
+export async function fetchFormulas() {
+  const { data, error } = await supabase.from('formulas').select('*').order('id', { ascending: true })
+  return { data, error }
+}
+

--- a/public/symbols.html
+++ b/public/symbols.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Symbols</title>
+</head>
+<body>
+<h1>Symbols</h1>
+<form id="symbol-form">
+  <input name="symbol" placeholder="Symbol" required />
+  <input name="value" placeholder="Value" required />
+  <button type="submit">Add</button>
+</form>
+<ul id="symbol-list"></ul>
+
+<script type="module">
+import { insertSymbol, fetchSymbols } from './supabase.js'
+
+const form = document.getElementById('symbol-form')
+const list = document.getElementById('symbol-list')
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault()
+  const symbol = form.symbol.value.trim()
+  const value = form.value.value.trim()
+  if (!symbol || !value) return
+  const { error } = await insertSymbol(symbol, value)
+  if (error) {
+    alert(error.message)
+  } else {
+    form.reset()
+    load()
+  }
+})
+
+async function load() {
+  const { data, error } = await fetchSymbols()
+  if (error) {
+    list.innerHTML = '<li>Failed to load symbols</li>'
+    return
+  }
+  list.innerHTML = ''
+  data.forEach(item => {
+    const li = document.createElement('li')
+    li.textContent = `${item.symbol}: ${item.value}`
+    list.appendChild(li)
+  })
+}
+
+load()
+</script>
+</body>
+</html>
+

--- a/public/vocabulary.html
+++ b/public/vocabulary.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Vocabulary</title>
+</head>
+<body>
+<h1>Vocabulary</h1>
+<form id="vocab-form">
+  <input name="word" placeholder="Word" required />
+  <input name="definition" placeholder="Definition" required />
+  <button type="submit">Add</button>
+</form>
+<ul id="vocab-list"></ul>
+
+<script type="module">
+import { insertVocabulary, fetchVocabulary } from './supabase.js'
+
+const form = document.getElementById('vocab-form')
+const list = document.getElementById('vocab-list')
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault()
+  const word = form.word.value.trim()
+  const definition = form.definition.value.trim()
+  if (!word || !definition) return
+  const { error } = await insertVocabulary(word, definition)
+  if (error) {
+    alert(error.message)
+  } else {
+    form.reset()
+    load()
+  }
+})
+
+async function load() {
+  const { data, error } = await fetchVocabulary()
+  if (error) {
+    list.innerHTML = '<li>Failed to load vocabulary</li>'
+    return
+  }
+  list.innerHTML = ''
+  data.forEach(item => {
+    const li = document.createElement('li')
+    li.textContent = `${item.word}: ${item.definition}`
+    list.appendChild(li)
+  })
+}
+
+load()
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- add basic Supabase client helper
- create pages for vocabulary, symbols, formulas, signup, login, forgot password, reset password, and a simple dashboard
- document setup and usage in README

## Testing
- `git status --short`